### PR TITLE
fix(sticker): Fix to reject negative option for search query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/garebareDA/discordRadio
+module github.com/bohkai/takop
 
 go 1.18
 

--- a/sticker.go
+++ b/sticker.go
@@ -43,6 +43,11 @@ func (st *sticker) Serch(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 		imageIndex = i
 
+		if imageIndex < 0 {
+			s.ChannelMessageSend(m.ChannelID, "オプションの値が小さすぎるッピ!")
+			return
+		}
+
 		if imageIndex >= 10 {
 			s.ChannelMessageSend(m.ChannelID, "オプションの値が大きすぎるッピ!")
 			return


### PR DESCRIPTION
If sticker command get negative number option, it will cause a fatal error with negative index access to slice. (#3)

This PR fixes this issue by checking the option is positive number.